### PR TITLE
fix: #28 Correct symbol filtering based on s.doc_sym.do_skip attribute

### DIFF
--- a/bundled/tool/common/symbols.py
+++ b/bundled/tool/common/symbols.py
@@ -24,6 +24,7 @@ from jaclang.compiler.absyntree import (
     WhileStmt,
     WithStmt,
     IterForStmt,
+    InForStmt,
     ModuleCode,
     AstImplOnlyNode,
 )
@@ -102,6 +103,11 @@ class Symbol:
             else node.decl if isinstance(node, JSymbol) else node
         )
         self.doc_uri = doc_uri
+
+
+    @property
+    def do_skip(self):
+        return isinstance(self.node, (IfStmt, WhileStmt, WithStmt, IterForStmt, InForStmt))
 
     @property
     def sym_name(self):

--- a/bundled/tool/common/utils.py
+++ b/bundled/tool/common/utils.py
@@ -186,6 +186,9 @@ def get_all_symbols(
     for sym in doc.symbols:
         if not include_impl and sym.sym_type == "impl":
             continue
+        if sym.do_skip:
+            yield from get_all_children(ls, sym, True)
+            continue
         yield sym
         yield from sym.uses(ls)
         yield from get_all_children(ls, sym, True)

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -358,7 +358,7 @@ def document_symbol(ls, params: lsp.DocumentSymbolParams) -> list[lsp.DocumentSy
     doc = ls.workspace.get_text_document(uri)
     if not hasattr(doc, "symbols"):
         update_doc_tree(ls, doc.uri)
-    doc_syms = [s.doc_sym for s in doc.symbols]
+    doc_syms = [s.doc_sym for s in doc.symbols if not s.do_skip]
     return doc_syms
 
 @LSP_SERVER.feature(


### PR DESCRIPTION
# **Name of PR**

fix: #28 Correct symbol filtering based on s.doc_sym.do_skip attribute

## **Description**
Description:
- Fixed an issue where symbols with s.doc_sym.do_skip set to True were erroneously included in the doc_syms list.
- Implemented proper filtering to exclude symbols where s.doc_sym.do_skip evaluates to True.

This fix ensures that only symbols intended to be included are added to the doc_syms list, addressing the bug in symbol filtering.
